### PR TITLE
Quick fix to make shift-to-parens like mappings configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/tekezo/Karabiner-Elements.svg?branch=master)](https://travis-ci.org/tekezo/Karabiner-Elements)
 [![License](https://img.shields.io/badge/license-Public%20Domain-blue.svg)](https://github.com/tekezo/Karabiner-Elements/blob/master/LICENSE.md)
 
 # Karabiner-Elements
@@ -7,14 +6,16 @@ Karabiner-Elements is the subset of the next generation Karabiner for macOS Sier
 
 ## Project Status
 
-Karabiner-Elements works fine.
+This repo contains quick fix to make shift-to-parens like key mappings to work. [See example](https://gist.github.com/IvanRublev/2da1c7447d0458989d4654b5c35c22b4#file-karabiner-json) of `~/.config/karabiner/karabiner.json` configuration file with left/right shifts are mapped to appropriate parens.
 
-You can download the latest Karabiner-Elements from https://pqrs.org/latest/karabiner-elements-latest.dmg
+Download and install from the [Release](https://github.com/IvanRublev/Karabiner-Elements/releases) page.
+
+This custom build is based on **standalone-modifiers** branch of [Karabiner-Elements](https://github.com/wwwjfy/Karabiner-Elements/tree/standalone-modifiers)project fork by [wwwjfy](https://github.com/wwwjfy).
 
 ## System requirements
 
-* OS X 10.11.*
-* OS X 10.12.*
+- OS X 10.11.*
+- OS X 10.12.*
 
 # Usage
 
@@ -22,28 +23,27 @@ Detailed usage instructions are available [here](usage/README.md).
 
 ## Features
 
-* Simple key modification (change keys to another keys)
-* Support Secure Keyboard Entry (eg. Terminal, Password prompt)
-* Modifier flags sharing with all connected keyboards.
+- Simple key modification (change keys to another keys)
+- Support Secure Keyboard Entry (eg. Terminal, Password prompt)
+- Modifier flags sharing with all connected keyboards.
 
 ## Limitations
 
-* Karabiner-Elements cannot modify eject key due to the limitation of macOS API.
-* Karabiner-Elements ignores the `System Preferences > Keyboard > Modifier Keys...` configuration.
+- Karabiner-Elements cannot modify eject key due to the limitation of macOS API.
+- Karabiner-Elements ignores the `System Preferences > Keyboard > Modifier Keys...` configuration.
 
 ## How to build
 
 System requirements:
 
-* OS X 10.11+
-* Xcode 8+
-* Command Line Tools for Xcode
-* Boost 1.61.0+ (header-only) http://www.boost.org/
+- OS X 10.11+
+- Xcode 8+
+- Command Line Tools for Xcode
+- Boost 1.61.0+ (header-only) <http://www.boost.org/>
 
 To install the Boost requirement, [download the latest Boost release](http://www.boost.org/), open the `boost` folder inside of it, and move all of the files there into `/opt/local/include/boost/`.
 
 (For example, the version.hpp should be located in `/opt/local/include/boost/version.hpp`)
-
 
 ### Step 1: Getting source code
 
@@ -64,4 +64,4 @@ The `make` script will create a redistributable **Karabiner-Elements-VERSION.dmg
 
 # Donations
 
-If you would like to contribute financially to the development of Karabiner Elements, donations can be made via https://pqrs.org/osx/karabiner/donation.html.en.
+If you would like to contribute financially to the development of Karabiner Elements, donations can be made via <https://pqrs.org/osx/karabiner/donation.html.en>.

--- a/scripts/codesign-pkg.sh
+++ b/scripts/codesign-pkg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CODESIGN_IDENTITY='79E265756C43F62E157DB5C8FA405B54428653F9'
+CODESIGN_IDENTITY='F0D76F38970A65FD50D19023BB62A2FF9AFDC99E'
 
 # ------------------------------------------------------------
 PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH

--- a/scripts/codesign-pkg.sh
+++ b/scripts/codesign-pkg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CODESIGN_IDENTITY='F0D76F38970A65FD50D19023BB62A2FF9AFDC99E'
+CODESIGN_IDENTITY='844024B19AFE3D0747C675FA6EA809E508C15F8B'
 
 # ------------------------------------------------------------
 PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH

--- a/scripts/codesign.sh
+++ b/scripts/codesign.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CODESIGN_IDENTITY='8ECD43BA902B40380BD84C4512385E6C5EB3F160'
+CODESIGN_IDENTITY='184CFD8DD811220EF4280867071B1218F97931E6'
 
 # ------------------------------------------------------------
 PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH

--- a/scripts/codesign.sh
+++ b/scripts/codesign.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CODESIGN_IDENTITY='184CFD8DD811220EF4280867071B1218F97931E6'
+CODESIGN_IDENTITY='84F6733015E5B993E983C1919E50244AE945CC34'
 
 # ------------------------------------------------------------
 PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH

--- a/src/core/grabber/include/manipulator/event_manipulator.hpp
+++ b/src/core/grabber/include/manipulator/event_manipulator.hpp
@@ -333,16 +333,7 @@ private:
     auto it = one_to_many_mappings_key_code_map_.find(key_code);
     if (it != one_to_many_mappings_key_code_map_.end()) {
       auto to_key_codes = it->second;
-      for (auto it2 = to_key_codes.begin(); it2 != to_key_codes.end(); it2++) {
-        if ((krbn::types::get_modifier_flag(*it2) != krbn::modifier_flag::zero) == pressed) {
-          post_key(*it2, pressed, timestamp);
-        }
-      }
-      for (auto it2 = to_key_codes.begin(); it2 != to_key_codes.end(); it2++) {
-        if ((krbn::types::get_modifier_flag(*it2) != krbn::modifier_flag::zero) != pressed) {
-          post_key(*it2, pressed, timestamp);
-        }
-      }
+      post_keys_sequence(to_key_codes, pressed, timestamp);
       return true;
     }
     return false;
@@ -376,8 +367,8 @@ private:
       if (from_key_code == standalone_from_key_ && standalone_keys_timer_ != nullptr) {
         standalone_keys_timer_ = nullptr;
         auto to_standalone_key_code = standalone_keys_key_code_map_.find(from_key_code)->second;
-        post_key(to_standalone_key_code, true, timestamp);
-        post_key(to_standalone_key_code, false, timestamp);
+        post_keys_sequence(to_standalone_key_code, true, timestamp);
+        post_keys_sequence(to_standalone_key_code, false, timestamp);
         return true;
       } else {
         return false;
@@ -385,14 +376,27 @@ private:
     }
   }
 
-  bool post_standalone_key(krbn::key_code key_code, uint64_t timestamp) {
-    auto it = standalone_keys_key_code_map_.find(key_code);
-    if (it != standalone_keys_key_code_map_.end()) {
-      post_key(it->second, true, timestamp);
-      post_key(it->second, false, timestamp);
-      return true;
-    }
-    return false;
+//  bool post_standalone_key(krbn::key_code key_code, uint64_t timestamp) {
+//    auto it = standalone_keys_key_code_map_.find(key_code);
+//    if (it != standalone_keys_key_code_map_.end()) {
+//      post_key(it->second, true, timestamp);
+//      post_key(it->second, false, timestamp);
+//      return true;
+//    }
+//    return false;
+//  }
+
+  void post_keys_sequence(std::vector<key_code> key_codes, bool pressed, uint64_t timestamp) {
+      for (auto it2 = key_codes.begin(); it2 != key_codes.end(); it2++) {
+          if ((krbn::types::get_modifier_flag(*it2) != krbn::modifier_flag::zero) == pressed) {
+              post_key(*it2, pressed, timestamp);
+          }
+      }
+      for (auto it2 = key_codes.begin(); it2 != key_codes.end(); it2++) {
+          if ((krbn::types::get_modifier_flag(*it2) != krbn::modifier_flag::zero) != pressed) {
+              post_key(*it2, pressed, timestamp);
+          }
+      }
   }
 
   void post_key(key_code key_code, bool pressed, uint64_t timestamp) {
@@ -454,7 +458,7 @@ private:
 
   std::unordered_map<key_code, key_code> simple_modifications_key_code_map_;
   std::unordered_map<key_code, key_code> fn_function_keys_key_code_map_;
-  std::unordered_map<key_code, key_code> standalone_keys_key_code_map_;
+  std::unordered_map<key_code, std::vector<key_code>> standalone_keys_key_code_map_;
   std::unordered_map<key_code, std::vector<key_code>> one_to_many_mappings_key_code_map_;
   key_code standalone_from_key_;
   std::unique_ptr<gcd_utility::main_queue_timer> standalone_keys_timer_;

--- a/src/share/core_configuration.hpp
+++ b/src/share/core_configuration.hpp
@@ -581,9 +581,9 @@ public:
       {
         const std::string key = "standalone_keys";
         if (json.find(key) != json.end()) {
-          standalone_keys_ = std::make_unique<simple_modifications>(json[key]);
+          standalone_keys_ = std::make_unique<one_to_many_mappings>(json[key]);
         } else {
-          standalone_keys_ = std::make_unique<simple_modifications>(nullptr);
+          standalone_keys_ = std::make_unique<one_to_many_mappings>(nullptr);
         }
       }
       {
@@ -665,7 +665,7 @@ public:
       return fn_function_keys_->to_key_code_map(logger);
     }
 
-    const std::unordered_map<key_code, key_code> get_standalone_keys_key_code_map(spdlog::logger& logger) const {
+    const std::unordered_map<key_code, std::vector<key_code>> get_standalone_keys_key_code_map(spdlog::logger& logger) const {
       return standalone_keys_->to_key_code_map(logger);
     }
     const std::unordered_map<key_code, std::vector<key_code>> get_one_to_many_mappings_key_code_map_(spdlog::logger& logger) const {
@@ -735,7 +735,7 @@ public:
     bool selected_;
     std::unique_ptr<simple_modifications> simple_modifications_;
     std::unique_ptr<simple_modifications> fn_function_keys_;
-    std::unique_ptr<simple_modifications> standalone_keys_;
+    std::unique_ptr<one_to_many_mappings> standalone_keys_;
     std::unique_ptr<one_to_many_mappings> one_to_many_mappings_;
     std::unique_ptr<virtual_hid_keyboard> virtual_hid_keyboard_;
     std::vector<device> devices_;


### PR DESCRIPTION
Switched standalone_keys to take array value instead of string value.
To map `left shift` to `(` write in `karabiner.json`:
```
"standalone_keys": {
   "left_shift": ["left_shift", "9"]
}
```
_______________________________________________
P.S. Essential changes are in following 2 files:
src/core/grabber/include/manipulator/event_manipulator.hpp
src/share/core_configuration.hpp